### PR TITLE
Set libvips as primary image processor.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'ancestry'
 
 # active-storage
 gem 'aws-sdk-s3', require: false
+gem 'image_processing', '~> 1.0'
 
 # authentication
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    image_processing (1.6.0)
+      mini_magick (~> 4.0)
+      ruby-vips (>= 2.0.11, < 3)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
@@ -177,6 +180,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mimemagic (0.3.2)
+    mini_magick (4.8.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -259,6 +263,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
+    ruby-vips (2.0.13)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.7)
@@ -371,6 +377,7 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id (~> 5.2.0)
   groupdate
+  image_processing (~> 1.0)
   jbuilder (~> 2.5)
   letter_opener
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [NodeJS (>=10.x)](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)
 - [Yarn](https://yarnpkg.com/lang/en/docs/install/#debian-stable)
 - [Redis](https://packages.debian.org/search?keywords=redis)
+- [libvips](https://github.com/jcupitt/libvips/wiki/Build-for-Ubuntu)
 
 ## Setup
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,9 @@ module Nokul
     # use app-wide e-mail template for devise
     config.to_prepare { Devise::Mailer.layout 'mailer' }
 
+    # image-processor
+    config.active_storage.variant_processor = :vips
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Closes #187.

@omu/ops libvips için README'ye eklediğim dökümanı (https://github.com/jcupitt/libvips/wiki/Build-for-Ubuntu) takip ettim, ayrıca resmi dökümana göre şu paketlerde gerekiyordu:

```
glib2.0-dev libexpat1-dev pkg-config
```

bunlar haricinde dikkat edilmesi gereken bir şey varsa dökümante ederseniz sevinirim.