### PR TITLE
Add a third-party libvips buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git#v123
 https://github.com/heroku/heroku-buildpack-ruby.git#v183
+https://github.com/mokolabs/heroku-buildpack-vips.git


### PR DESCRIPTION
Should be replaced with a well-maintained buildpack in the future.

Fixes #198