### PR TITLE
Duty, Position ve Employee controller testlerini ekle

### DIFF
--- a/test/controllers/accounts/duties_controller_test.rb
+++ b/test/controllers/accounts/duties_controller_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Accounts
+  class DutiesController < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:serhat)
+      @unit = units(:cbu)
+      sign_in @user
+    end
+
+    test 'should get new' do
+      get new_user_duty_path(@user)
+      assert_response :success
+    end
+
+    test 'should create duty' do
+      assert_difference('@user.duties.count') do
+        post user_duties_path(@user), params: {
+          duty: {
+            employee_id: employees(:serhat_active).id, unit_id: @unit.id, temporary: true, start_date: '01.09.2018'
+          }
+        }
+      end
+
+      duty = @user.duties.last
+
+      assert_equal employees(:serhat_active), duty.employee
+      assert_equal @unit, duty.unit
+      assert_equal true, duty.temporary
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.create.success'), flash[:notice]
+    end
+
+    test 'should update duty' do
+      duty = @user.duties.first
+
+      patch user_duty_path(@user, duty), params: {
+        duty: {
+          unit_id: @unit.id, temporary: true
+        }
+      }
+
+      duty.reload
+
+      assert_equal @unit, duty.unit
+      assert_equal true, duty.temporary
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.update.success'), flash[:notice]
+    end
+
+    test 'should destroy duty' do
+      assert_difference('@user.duties.count', -1) do
+        delete user_duty_path(@user, @user.duties.last)
+      end
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.destroy.success'), flash[:notice]
+    end
+
+    private
+
+    def translate(key)
+      t("account.duties#{key}")
+    end
+  end
+end

--- a/test/controllers/accounts/employees_controller_test.rb
+++ b/test/controllers/accounts/employees_controller_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Accounts
+  class EmployeesController < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:serhat)
+      @title = titles(:chief)
+      sign_in @user
+    end
+
+    test 'should get new' do
+      get new_user_employee_path(@user)
+      assert_response :success
+    end
+
+    test 'should create employee' do
+      assert_difference('@user.employees.count') do
+        post user_employees_path(@user), params: {
+          employee: {
+            title_id: @title.id, active: false
+          }
+        }
+      end
+
+      employee = @user.employees.last
+
+      assert_equal @title, employee.title
+      assert_equal false, employee.active
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.create.success'), flash[:notice]
+    end
+
+    test 'should update employee' do
+      employee = @user.employees.first
+
+      patch user_employee_path(@user, employee), params: {
+        employee: {
+          title_id: @title.id, active: false
+        }
+      }
+
+      employee.reload
+
+      assert_equal @title, employee.title
+      assert_equal false, employee.active
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.update.success'), flash[:notice]
+    end
+
+    test 'should destroy employee' do
+      assert_difference('@user.employees.count', -1) do
+        delete user_employee_path(@user, @user.employees.last)
+      end
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.destroy.success'), flash[:notice]
+    end
+
+    private
+
+    def translate(key)
+      t("account.employees#{key}")
+    end
+  end
+end

--- a/test/controllers/accounts/positions_controller_test.rb
+++ b/test/controllers/accounts/positions_controller_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Accounts
+  class PositionsController < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:serhat)
+      @administrative_function = administrative_functions(:yok_member)
+      @duty = duties(:baum)
+      sign_in @user
+    end
+
+    test 'should get new' do
+      get new_user_position_path(@user)
+      assert_response :success
+    end
+
+    test 'should create position' do
+      assert_difference('@user.positions.count') do
+        post user_positions_path(@user), params: {
+          position: {
+            administrative_function_id: @administrative_function.id, duty_id: @duty.id,
+            start_date: '01.01.2013', end_date: '01.01.2015'
+          }
+        }
+      end
+
+      position = @user.positions.last
+
+      assert_equal @administrative_function, position.administrative_function
+      assert_equal @duty, position.duty
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.create.success'), flash[:notice]
+    end
+
+    test 'should update position' do
+      position = @user.positions.first
+
+      patch user_position_path(@user, position), params: {
+        position: {
+          duty_id: @duty.id, administrative_function_id: @administrative_function.id
+        }
+      }
+
+      position.reload
+
+      assert_equal @duty, position.duty
+      assert_equal @administrative_function, position.administrative_function
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.update.success'), flash[:notice]
+    end
+
+    test 'should destroy position' do
+      assert_difference('@user.positions.count', -1) do
+        delete user_position_path(@user, @user.positions.last)
+      end
+
+      assert_redirected_to user_path(@user)
+      assert_equal translate('.destroy.success'), flash[:notice]
+    end
+
+    private
+
+    def translate(key)
+      t("account.positions#{key}")
+    end
+  end
+end

--- a/test/fixtures/positions.yml
+++ b/test/fixtures/positions.yml
@@ -1,7 +1,7 @@
 baum_dean:
   administrative_function: dean
   duty: baum
-  start_date: 01.01.2017
+  start_date: 01.01.2016
   end_date: <%= Time.zone.now - 2.years %>
 omu_rector:
   administrative_function: rector


### PR DESCRIPTION
**Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın:**

DutiesController, PositionsController ve EmployeesController isimli controller'ların testleri eksikti, eklendi.

Bir position fixture kaydı validasyonda bulunduğumuz tarih için end_date start_date'ten önce girilmiş hatası veriyordu, gereksiz hata almamak için değiştirildi.

**İlgili iş kayıtları:**

#279 

**Kapatılacak iş kayıtları:**

Closes #279 

**Veritabanına etkileri:**

**Sistem/Ops etkileri:**

**Kontrol listesi:**

* [x] Açtığınız PR'in başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi vb.) uygun mu?
* [x] [Katkı sağlama dokümanını](https://github.com/omu/nokul/CONTRIBUTING.md) okudunuz mu?
* [x] Yaptığınız iş/değişikliği dokümante ettiniz mi?
* [x] Yaptığınız iş/değişikliğin testlerini yazdınız mı?
* [x] Test coverage oranını kontrol ettiniz mi?
* [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor mu?
* [x] Kendinizi bu PR'e assign ettiniz mi?
* [x] Yaptığınız iş/değişiklik ile ilgili **tüm** proje üyelerinden review talep ettiniz mi?
* [x] Gerekli etiketleri (bug, feature-step, help-wanted vb.) girdiniz mi?

**Ek içerik:**

[//]: # (Kaynaklar, dış bağlantılar, ekran görüntüleri, örnek çözümler ve benzeri diğer kaynakları ekleyiniz.)
