### PR TITLE
Remove outputs/null from progressbar

### DIFF
--- a/lib/support/ext/progress_bar.rb
+++ b/lib/support/ext/progress_bar.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby-progressbar/outputs/null'
-
 class ProgressBar
   def self.spawn(title, total, output = $stdout)
     ProgressBar.create(title: title, total: total, format: '%t %B %c/%C %a', output: output) if Rails.env.development?


### PR DESCRIPTION
**Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın:**

[//]: # (Kısa ve net bir şekilde bu PR'e neden ihtiyaç var, ne iş/değişiklik yapıyor açıklanmalıdır.)

`ENV['CI']` durumunda hataya düşen `require 'ruby-progressbar/outputs/null'` satırını kaldırır. Hali hazırda zaten stdout'a bastığımız için bu satırın bir anlamı da bulunmuyor.
