### PR TITLE
CI'daki ruby-vips ve webdrivers hatasını düzelt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'ancestry'
 # active-storage
 gem 'aws-sdk-s3', require: false
 gem 'image_processing', '~> 1.2'
+gem 'ruby-vips', '2.0.13'
 
 # authentication
 gem 'authy'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.70.0)
     ruby-progressbar (1.10.1)
-    ruby-vips (2.0.14)
+    ruby-vips (2.0.13)
       ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
@@ -467,6 +467,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   ruby-progressbar
+  ruby-vips (= 2.0.13)
   sassc-rails
   sidekiq
   simple_form

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,7 +9,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     [768, 1024],  # tablet
     [360, 640]    # small mobile device
   ].freeze
-  
+
   Capybara.server = :puma, { Silent: true }
 
   Capybara.register_driver 'chrome_headless' do |driver|
@@ -26,9 +26,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     options.add_argument '--disable-gpu'
     options.add_argument '--disable-dev-shm-usage'
     options.add_argument '--disable-popup-blocking'
-  
+
     Capybara::Selenium::Driver.new(driver, browser: :chrome, options: options)
   end
-  
+
   driven_by 'chrome_headless'
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,19 +3,32 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1920, 1080], options: {
-    desired_capabilities: {
-      chromeOptions: {
-        args: %w[no-sandbox headless disable-gpu disable-dev-shm-usage]
-      }
-    }
-  }
-  Capybara.server = :puma, { Silent: true }
-
   SUPPORTED_SCREEN_RESOLUTIONS = [
     [1920, 1080], # desktop
-    [1366, 768], # ultrabook
-    [768, 1024], # tablet
-    [360, 640] # small mobile device
+    [1366, 768],  # ultrabook
+    [768, 1024],  # tablet
+    [360, 640]    # small mobile device
   ].freeze
+  
+  Capybara.server = :puma, { Silent: true }
+
+  Capybara.register_driver 'chrome_headless' do |driver|
+    options = Selenium::WebDriver::Chrome::Options.new
+
+    if ActiveRecord::Type::Boolean.new.cast(ENV['NO_HEADLESS'])
+      options.add_argument '--start-maximized'
+      options.add_argument '--auto-open-devtools-for-tabs'
+    else
+      options.add_argument '--headless'
+    end
+
+    options.add_argument '--no-sandbox'
+    options.add_argument '--disable-gpu'
+    options.add_argument '--disable-dev-shm-usage'
+    options.add_argument '--disable-popup-blocking'
+  
+    Capybara::Selenium::Driver.new(driver, browser: :chrome, options: options)
+  end
+  
+  driven_by 'chrome_headless'
 end

--- a/test/system/vips_test.rb
+++ b/test/system/vips_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'vips'
 
 class VipsTest < ActiveSupport::TestCase
   test 'Test vips library' do
@@ -11,8 +12,6 @@ class VipsTest < ActiveSupport::TestCase
 
   # example from https://github.com/libvips/ruby-vips/blob/master/example/example3.rb
   def annote
-    require 'vips'
-
     im = Vips::Image.new_from_file file_fixture('valid_png_picture.png').to_s
     im.embed 100, 100, 3000, 3000, extend: :mirror
   end


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

ruby-vips sürümü 2.0.14'ten 2.0.13'e düşürüldü. Bunun nedeni sistem testleri sırasında `require 'vips'` satırının çalışmaması.

webdrivers gem'inin 4 sürümüyle birlikte driven_by komutuna verilen argümanların sözdizimi değiştiğinden gerekli güncellemeler yapılmıştır.

#### İlgili/kapatılacak iş kayıtları

N/A

#### Teknik borç kayıtları

N/A

#### Veritabanına etkileri

N/A

#### Sistem etkileri

N/A

#### Kontrol listesi

- [x] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [x] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [x] Yapılan iş/değişikliği dokümante ettim
- [x] Yapılan iş/değişikliğin testlerini yazdım
- [x] Test coverage oranını kontrol ettim
- [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [x] Kendimi bu PR'e assign ettim
- [x] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [x] Gerekli etiketlemeyi (ör. bug) yaptım
