### PR TITLE
Provizyonlama sonrası firewall'u kapat

### DIFF
--- a/lib/scripts/deploy.sh
+++ b/lib/scripts/deploy.sh
@@ -66,3 +66,5 @@ sudo -EH -u "$operator" bash -xs <<-'EOF'
 		bin/rails db:seed SAMPLE_DATA=true
 	fi
 EOF
+
+systemctl disable ufw


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

PR, Vagrant'da provizyonlama adımında `ufw`yi kapatır.

#### İlgili/kapatılacak iş kayıtları

n/a

#### Teknik borç kayıtları

n/a
#### Veritabanına etkileri

n/a

#### Sistem etkileri

Vagrant'da `omu/debian-stable-server` imajını `2.19.1` sürümü ile birlikte kullananlar host'tan uygulamaya (`localhost:3000`) erişim sorunu yaşıyor ise makineyi silip tekrar oluşturmalıdır:

```sh
vagrant destroy -f
vagrant up
```

#### Kontrol listesi

- [X] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [X] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [ ] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [X] Test coverage oranını kontrol ettim
- [X] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [ ] Kendimi bu PR'e assign ettim
- [X] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [X] Gerekli etiketlemeyi (ör. bug) yaptım

#### Ek içerik

n/a