### PR TITLE
Lograge gem'ini ekle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'nexmo'
 gem 'smstools'
 gem 'twilio-ruby'
 
+# log
+gem 'lograge'
+
 group :development, :test do
   gem 'brakeman', require: false
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,11 @@ GEM
     listen (3.2.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lograge (0.11.2)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     lol_dba (2.1.5)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -293,6 +298,8 @@ GEM
     rein (5.0.0)
       activerecord (>= 4.0.0)
       activesupport (>= 4.0.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -432,6 +439,7 @@ DEPENDENCIES
   jbuilder (~> 2.9)
   letter_opener
   listen (>= 3.0.5, < 3.3)
+  lograge
   lol_dba
   minitest-focus
   net-ldap

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,13 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def append_info_to_payload(payload)
+    super
+    payload[:host] = request.host
+    payload[:remote_ip] = request.remote_ip
+    payload[:user_id] = current_user.try(:id)
+  end
+
   def search_params(model = nil)
     parameters = [:term]
     parameters << model.dynamic_search_keys if model

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.keep_original_rails_log = true
 
-  config.lograge.logger = ActiveSupport::Logger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
+  config.lograge.logger = ActiveSupport::Logger.new Rails.root.join('log', "lograge_#{Rails.env}.log")
   config.lograge.formatter = Lograge::Formatters::Json.new
 
   config.lograge.custom_options = lambda do |event|
-    exceptions = %w(controller action format id)
+    exceptions = %w[controller action format id]
     {
-      time: Time.now,
-      params: event.payload[:params].except(*exceptions),
-      exception: event.payload[:exception],
+      time:             Time.current,
+      params:           event.payload[:params].except(*exceptions),
+      exception:        event.payload[:exception],
       exception_object: event.payload[:exception_object],
-      host: event.payload[:host],
-      remote_ip: event.payload[:remote_ip],
-      user_id: event.payload[:user_id]
+      host:             event.payload[:host],
+      remote_ip:        event.payload[:remote_ip],
+      user_id:          event.payload[:user_id]
     }
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,20 @@
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.keep_original_rails_log = true
+
+  config.lograge.logger = ActiveSupport::Logger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
+  config.lograge.formatter = Lograge::Formatters::Json.new
+
+  config.lograge.custom_options = lambda do |event|
+    exceptions = %w(controller action format id)
+    {
+      time: Time.now,
+      params: event.payload[:params].except(*exceptions),
+      exception: event.payload[:exception],
+      exception_object: event.payload[:exception_object],
+      host: event.payload[:host],
+      remote_ip: event.payload[:remote_ip],
+      user_id: event.payload[:user_id]
+    }
+  end
+end


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

Rails'in varsayılan logları, bir istek için pek çok satır içeriyor. Log toplama servislerinde bu durum karışıklığa neden olmaktadır. Bu yapılandırmanın bize bir diğer avantajı ise loglara kullanıcı id'si, remote ip gibi ekstra alanlar ekleyebilmek.

Örnek:

Rails varsayılan log:

```text
Started GET "/" for 172.18.0.1 at 2019-10-31 12:47:21 +0300
Cannot render console from 172.18.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
    (1.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC                                                                                 
Processing by HomeController#index as HTML
Completed 401 Unauthorized in 9ms (ActiveRecord: 0.0ms | Allocations: 1092)


Started GET "/users/sign_in" for 172.18.0.1 at 2019-10-31 12:47:21 +0300
Cannot render console from 172.18.0.1! Allowed networks: 127.0.0.0/127.255.255.255, ::1
Processing by Account::SessionsController#new as HTML
   Rendering account/sessions/new.html.erb within layouts/guest
   Rendered account/sessions/new.html.erb within layouts/guest (Duration: 118.5ms | Allocations: 14779)                                                                                               
   Rendered layouts/shared/_meta.html.erb (Duration: 2.0ms | Allocations: 451)
   Rendered layouts/shared/_toastr.html.erb (Duration: 1.3ms | Allocations: 249)
   Rendered layouts/shared/_footer.html.erb (Duration: 24.9ms | Allocations: 6024)
Completed 200 OK in 625ms (Views: 537.4ms | ActiveRecord: 13.9ms | Allocations: 161517)
```

Lograge Log:

```json
{"method":"GET","path":"/","format":"html","controller":"HomeController","action":"index","status":0,"duration":8.84,"view":0.0,"db":0.0,"time":"2019-10-31 12:47:21 +0300","params":{},"exception":null,"exception_object":null,"host":"localhost","remote_ip":"172.18.0.1","user_id":null}
{"method":"GET","path":"/users/sign_in","format":"html","controller":"Account::SessionsController","action":"new","status":200,"duration":624.99,"view":537.42,"db":13.9,"time":"2019-10-31 12:47:22 +0300","params":{},"exception":null,"exception_object":null,"host":"localhost","remote_ip":"172.18.0.1","user_id":null}
```

Rails'in orijinal log'unu korumasını istedim çünkü `dokku logs` komutu, yalnızca konteynerin stdout'a yazdığı logları gösterebiliyor.

lograge yapılandırmasını yalnızca production'a ekleyebilirdim ancak yerelde de geliştiriciler kullanmak isteyebilir diye `config/initializers` altına ekledim.

#### İlgili/kapatılacak iş kayıtları

[//]: # (PR merge edildiğinde hangi iş kayıtları kapatılacak ise `Closes`, `Fixes` gibi anahtar kelimeler ile birlikte ID numaralarını listele)
[//]: # (Kapatılmayan ancak referans verilecek iş kayıtları için `References` anahtar kelimesini kullan)

#### Teknik borç kayıtları

[//]: # (PR ile geliştirilen çözümün eksiklikleri varsa "Teknik borç" türünde iş kayıtları oluşturulmalı)
[//]: # (İş kaydını ön izlemeye al ve aşağıda görüntülenen bağlantıyı yeni sekmede aç)
[//]: # (Bu şekilde oluşturulan kayıtları `References` anahtar kelimesiyle listele)
[//]: # (DİKKAT! TEKNİK BORÇ YOKSA AŞAĞIDAKİ SATIRI N/A İLE DEĞİŞTİRİN VEYA SİLİN!)

#### Veritabanına etkileri

[//]: # (PR merge edildiğinde veritabanı üzerinde herhangi bir düzenleme gerekecek mi?)
[//]: # (Örnek: migration, seed, add/drop)

#### Sistem etkileri

Üretilen logları log toplama servislerine yönlendirecek yapılandırmalar gerekmekte.

[//]: # (PR merge edildiğinde sunucular üzerinde herhangi bir düzenleme gerekecek mi?)
[//]: # (Örnek: yeni paket kurulması, buildpack eklenmesi)

#### Kontrol listesi

- [x] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [x] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [x] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [x] Test coverage oranını kontrol ettim
- [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [x] Kendimi bu PR'e assign ettim
- [x] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [x] Gerekli etiketlemeyi (ör. bug) yaptım

#### Ek içerik

[//]: # (Kaynaklar)
[//]: # (Dış bağlantılar)
[//]: # (Ekran görüntüleri)
[//]: # (Örnek çözümler)
