### PR TITLE
wkhtmltopdf-binary gemini kaldır

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'groupdate'
 gem 'pagy'
 gem 'simple_form'
 gem 'wicked_pdf'
-gem 'wkhtmltopdf-binary'
 
 # api
 gem 'jbuilder', '~> 2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,7 +412,6 @@ GEM
     websocket-extensions (0.1.4)
     wicked_pdf (1.4.0)
       activesupport
-    wkhtmltopdf-binary (0.12.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.2.1)
@@ -492,7 +491,6 @@ DEPENDENCIES
   webmock
   webpacker
   wicked_pdf
-  wkhtmltopdf-binary
 
 RUBY VERSION
    ruby 2.6.4p104


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

`wkhtmltopdf` çalıştırılabilir dosyası imajlarla zaten geldiği için gem ile tekrar kurmak gerekmiyor. PR, `wkhtmltopdf-binary` gemini kaldırır ve sistemdeki çalıştırılabilir dosyanın kullanılmasını sağlar.

#### İlgili/kapatılacak iş kayıtları

Fixes #1200
Fixes #968  

#### Teknik borç kayıtları

- #1254

#### Veritabanına etkileri

n/a

#### Sistem etkileri

n/a

#### Kontrol listesi

- [X] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [X] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [ ] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [X] Test coverage oranını kontrol ettim
- [X] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [X] Kendimi bu PR'e assign ettim
- [X] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [X] Gerekli etiketlemeyi (ör. bug) yaptım

#### Ek içerik

n/a
