### PR TITLE
Handle unverified request with reset_session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,14 +4,14 @@ class ApplicationController < ActionController::Base
   include Pundit
   include Patron::Sudoable
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :reset_session
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
   before_action :set_locale
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
-  rescue_from Pundit::NotAuthorizedError,   with: :user_not_authorized
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def set_locale
     update_preferred_language if user_signed_in?
@@ -53,6 +53,11 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def handle_unverified_request
+    super
+    redirect_back(fallback_location: root_path, alert: t('errors.invalid_authenticity_token'))
+  end
 
   def user_not_authorized(exception)
     flash[:alert] = t(

--- a/config/locales/errors/en.yml
+++ b/config/locales/errors/en.yml
@@ -6,3 +6,4 @@ en:
     invalid_email: This is not a valid e-mail address!
     system_error: The system error has occurred. Please try later.
     unicode_not_supported: Receiver does not support unicode encoding!
+    invalid_authenticity_token: Invalid authenticity token! Please try again.

--- a/config/locales/errors/tr.yml
+++ b/config/locales/errors/tr.yml
@@ -6,3 +6,4 @@ tr:
     invalid_email: Geçerli bir e-mail adresi değil!
     system_error: Sistemsel bir hata oluştu. Lütfen daha sonra tekrar deneyin.
     unicode_not_supported: Alıcı numara unicode desteklemiyor!
+    invalid_authenticity_token: Geçersiz kimlik doğrulama jetonu! Lütfen tekrar deneyin.


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

ActionController::InvalidAuthenticityToken hatasını kibarca yönet.

#### İlgili/kapatılacak iş kayıtları

[//]: # (PR merge edildiğinde hangi iş kayıtları kapatılacak ise `Closes`, `Fixes` gibi anahtar kelimeler ile birlikte ID numaralarını listele)
[//]: # (Kapatılmayan ancak referans verilecek iş kayıtları için `References` anahtar kelimesini kullan)

Fixes #1374

#### Teknik borç kayıtları

[//]: # (PR ile geliştirilen çözümün eksiklikleri varsa "Teknik borç" türünde iş kayıtları oluşturulmalı)
[//]: # (İş kaydını ön izlemeye al ve aşağıda görüntülenen bağlantıyı yeni sekmede aç)
[//]: # (Bu şekilde oluşturulan kayıtları `References` anahtar kelimesiyle listele)
[//]: # (DİKKAT! TEKNİK BORÇ YOKSA AŞAĞIDAKİ SATIRI N/A İLE DEĞİŞTİRİN VEYA SİLİN!)

#### Veritabanına etkileri

[//]: # (PR merge edildiğinde veritabanı üzerinde herhangi bir düzenleme gerekecek mi?)
[//]: # (Örnek: migration, seed, add/drop)

#### Sistem etkileri

[//]: # (PR merge edildiğinde sunucular üzerinde herhangi bir düzenleme gerekecek mi?)
[//]: # (Örnek: yeni paket kurulması, buildpack eklenmesi)

#### Kontrol listesi

- [x] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [x] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [x] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [ ] Test coverage oranını kontrol ettim
- [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [x] Kendimi bu PR'e assign ettim
- [x] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [x] Gerekli etiketlemeyi (ör. bug) yaptım

#### Ek içerik
Konuyu herkesin anlaması için detaylı yazıyorum.

1. Deneme

```ruby
protect_from_forgery with: :exception

rescue_from ActionController::InvalidAuthenticityToken, with: :handle_csrf_error

private

def handle_csrf_error
  render file: 'public/422.html', layout: false, status: 422
end
```

Yukarıdaki kodla hatayı yakalayıp, 422 sayfasını render ettim. Burada şöyle bir sorun var. Kullanıcı TC ve parolayı doğru yazarsa, ancak token hatalıysa, kullanıcı içeri alınıyor, ardından 422 sayfası render ediliyordu. Bu istenen davranış değil doğal olarak. Token hatalıysa kullanıcıyı içeri almamalıyız.

Yukarıdaki soruna ne neden oluyor diye araştırınca; Devise, Rails'in bu exception'ı handle ettiği `handle_unverified_request` fonksiyonuna güvenerek işlem yaptığını gördüm: https://github.com/plataformatec/devise/blob/master/lib/devise/controllers/helpers.rb#L254

2. Deneme

`handle_unverified_request` fonksiyonunun üzerine yazmaya çalıştım, bu sefer Devise'ın https://github.com/plataformatec/devise/blob/master/lib/devise/controllers/helpers.rb#L254 burada yaptığı adımları yeniden yazmam gerekecekti, ancak bu da yanlış olurdu. Çünkü ileride Devise bu kodu değiştirebilirdi. Sürekli bakım yapma maliyeti doğardı.

3. Deneme

Farkettim ki ben bu `protect_from_forgery with: :exception` ifadesinin tam olarak nasıl çalıştığını bilmiyorum :grin:

https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html

Burayı okurken şu satırda aydınlanma yaşadım:

> Valid unverified request handling methods are:
>
> - :exception - Raises ActionController::InvalidAuthenticityToken exception.
>
> - :reset_session - Resets the session.
>
> - :null_session - Provides an empty session during request but doesn't reset it completely. Used as default if :with option is not specified.

Aslında istediğim `exception` değil `reset_session`mış.

Kodun son hali ise şöyle oldu:

```ruby
protect_from_forgery with: :reset_session

private

def handle_unverified_request
  super
  redirect_back(fallback_location: root_path, alert: t('errors.invalid_authenticity_token'))
end
```

Yukarıda `redirect_back` yerine  `render file: 'public/422.html', layout: false, status: 422` diyebilirdim. Ancak kullanıcı dostu olalım diye root'a yönlendirmek daha mantıklı geldi.