### PR TITLE
Oturumlar için timeout değerini düzenle

### DIFF
--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -7,7 +7,7 @@ module Account
 
     # GET /resource/sign_in
     def new
-      return super if Nokul::SSO.disable?
+      return super if Nokul::SSO.disabled?
 
       redirect_to(user_openid_connect_omniauth_authorize_path)
     end

--- a/app/controllers/account/sessions_controller.rb
+++ b/app/controllers/account/sessions_controller.rb
@@ -7,7 +7,7 @@ module Account
 
     # GET /resource/sign_in
     def new
-      return super unless ENV.fetch('NOKUL_SSO_ENABLE', false)
+      return super if Nokul::SSO.disable?
 
       redirect_to(user_openid_connect_omniauth_authorize_path)
     end

--- a/app/lib/nokul/sso.rb
+++ b/app/lib/nokul/sso.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Nokul
+  module SSO
+    module_function
+
+    def disable?
+      !enable?
+    end
+
+    def enable?
+      ActiveRecord::Type::Boolean.new.cast(
+        ENV.fetch('NOKUL_SSO_ENABLE', false)
+      )
+    end
+  end
+end

--- a/app/lib/nokul/sso.rb
+++ b/app/lib/nokul/sso.rb
@@ -5,7 +5,7 @@ module Nokul
     module_function
 
     def disabled?
-      !enable?
+      !enabled?
     end
 
     def enabled?

--- a/app/lib/nokul/sso.rb
+++ b/app/lib/nokul/sso.rb
@@ -8,7 +8,7 @@ module Nokul
       !enable?
     end
 
-    def enable?
+    def enabled?
       ActiveRecord::Type::Boolean.new.cast(
         ENV.fetch('NOKUL_SSO_ENABLE', false)
       )

--- a/app/lib/nokul/sso.rb
+++ b/app/lib/nokul/sso.rb
@@ -4,7 +4,7 @@ module Nokul
   module SSO
     module_function
 
-    def disable?
+    def disabled?
       !enable?
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,6 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable,
          :trackable, :validatable, :lockable, :timeoutable
   devise :omniauthable, omniauth_providers: %i[openid_connect]
-  devise :timeoutable, timeout_in: 5.minutes
 
   # relations
   has_one_attached :avatar

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -171,10 +171,10 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   config.timeout_in =
-    if Rails.env.development?
-      120.minutes
-    elsif Nokul::SSO.enable?
+    if Nokul::SSO.enable?
       5.minutes
+    elsif Rails.env.development?
+      120.minutes
     else
       45.minutes
     end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -171,7 +171,7 @@ Devise.setup do |config|
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
   config.timeout_in =
-    if Nokul::SSO.enable?
+    if Nokul::SSO.enabled?
       5.minutes
     elsif Rails.env.development?
       120.minutes

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -170,7 +170,14 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 45.minutes
+  config.timeout_in =
+    if Rails.env.development?
+      120.minutes
+    elsif Nokul::SSO.enable?
+      5.minutes
+    else
+      45.minutes
+    end
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -2,6 +2,7 @@
 
 Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
-    'ldap' => 'LDAP'
+    'ldap' => 'LDAP',
+    'sso'  => 'SSO'
   )
 end


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

`Timeout` değeri SSO entegrasyonundan sonra 5 dakika olarak ayarlanmış, bu ayardan dolayı geliştirme ortamında sürekli oturum sonlanma problemi yaşamaktaydık. Yapılan geliştirmeler bu sorunun çözümünü amaçlamaktadır.

- SSO için aktiflik durumunun `Nokul::SSO.enable?` çağrısı ile sorgulanması sağlandı.
- Devise yapılandırmasında `timeout_in` değerinin, çalışma ortamı ve SSO aktiflik durumuna göre farklı değerler alması sağlandı.

#### İlgili/kapatılacak iş kayıtları

Close #1427

#### Teknik borç kayıtları

N/A

#### Veritabanına etkileri

N/A

#### Sistem etkileri

N/A

#### Kontrol listesi

- [X] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [X] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [ ] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [X] Test coverage oranını kontrol ettim
- [X] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [X] Kendimi bu PR'e assign ettim
- [X] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [X] Gerekli etiketlemeyi (ör. bug) yaptım