### PR TITLE
Bina istatistiklerindeki sıralama yanlışını düzelt

### DIFF
--- a/app/views/meksis/buildings/index.html.erb
+++ b/app/views/meksis/buildings/index.html.erb
@@ -26,9 +26,9 @@
                 <td><%= building.name %></td>
                 <td><%= building.code %></td>
                 <td><%= building.place_type.name %></td>
-                <td><%= building.indoor_area %></td>
                 <td><%= building.classrooms.sum(:student_capacity) %></td>
                 <td><%= building.classrooms.sum(:exam_capacity) %></td>
+                <td><%= building.indoor_area %></td>
                 <td><%= icon_for_check building.active %></td>
                 <td><%= link_to_actions([:meksis, building], except: %i[new destroy]) %></td>
               </tr>


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

Bina istatistikleri sayfasında "Kapalı Alan", "Öğrenci Kapasitesi" ve "Sınav Kapasitesi" istatistiklerinde sıralama yanlışı var. PR, bu yanlışı düzeltir.

#### İlgili/kapatılacak iş kayıtları

Fixes #1460 

#### Teknik borç kayıtları

N/A

#### Veritabanına etkileri

N/A

#### Sistem etkileri

N/A

#### Kontrol listesi

- [X] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [X] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [ ] Yapılan iş/değişikliği dokümante ettim
- [ ] Yapılan iş/değişikliğin testlerini yazdım
- [X] Test coverage oranını kontrol ettim
- [X] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [X] Kendimi bu PR'e assign ettim
- [X] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [X] Gerekli etiketlemeyi (ör. bug) yaptım

#### Ek içerik

N/A
