### PR TITLE
Fix logout path

### DIFF
--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -21,7 +21,7 @@
         <%= link_to :settings, class: 'dropdown-item' do %>
           <%= fa_icon('shield', text: t('.account_settings'), class: 'mfe-2') %>
         <% end %>
-        <% if ENV.fetch('NOKUL_SSO_ENABLE', false) %>
+        <% if Nokul::SSO.enabled? %>
           <%= link_to "#{Tenant.credentials.lemonldap[:issuer]}/oauth2/logout", class: 'dropdown-item' do %>
             <%= fa_icon('lock', text: t('.logout'), class: 'mfe-2') %>
           <% end %>


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

SSO'nun aktif olmadığı durumlarda logout path'i yanlış gösteriliyordu, düzeltildi.

#### Kontrol listesi

- [x] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [x] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [x] Yapılan iş/değişikliği dokümante ettim
- [x] Yapılan iş/değişikliğin testlerini yazdım
- [x] Test coverage oranını kontrol ettim
- [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [x] Kendimi bu PR'e assign ettim
- [x] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [x] Gerekli etiketlemeyi (ör. bug) yaptım