### PR TITLE
Codacy coverage entegrasyonunu düzelt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - "$HOME/bundle"
     - "$HOME/.bundle_config"
     - "$HOME/node_modules"
+    - "$HOME/coverage"
 
 install:
   - docker-compose build test
@@ -37,7 +38,7 @@ jobs:
       # third job at this stage
     - name: "Integration Tests"
       before_script: skip
-      script: docker-compose run test bundle exec rails test:system test
+      script: docker-compose run test bundle exec rails test:system test && bash <(curl -Ls https://coverage.codacy.com/get.sh) -r $HOME/coverage/coverage.xml
 
     - stage: deploy
       # first job at this stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       # third job at this stage
     - name: "Integration Tests"
       before_script: skip
-      script: docker-compose run test bundle exec rails test:system test && bash <(curl -Ls https://coverage.codacy.com/get.sh) -r $HOME/coverage/coverage.xml
+      script: docker-compose run test bundle exec rails test:system test && bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Ruby -r $HOME/coverage/coverage.xml
 
     - stage: deploy
       # first job at this stage

--- a/Gemfile
+++ b/Gemfile
@@ -99,8 +99,8 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'codacy-coverage', require: false
   gem 'minitest-focus'
+  gem 'simplecov-cobertura'
   gem 'webdrivers', '~> 4.4'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,8 +142,6 @@ GEM
     chartkick (3.3.1)
     childprocess (3.0.0)
     cocoon (1.2.14)
-    codacy-coverage (2.2.1)
-      simplecov
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
@@ -392,6 +390,8 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
+    simplecov-cobertura (1.3.1)
+      simplecov (~> 0.8)
     simplecov-html (0.12.2)
     slack-notifier (2.3.2)
     smart_properties (1.15.0)
@@ -483,7 +483,6 @@ DEPENDENCIES
   capybara
   chartkick
   cocoon
-  codacy-coverage
   devise (>= 4.7.1)
   dotenv-rails (>= 2.7.5)
   erb_lint (>= 0.0.32)
@@ -530,6 +529,7 @@ DEPENDENCIES
   sidekiq-cron
   simple_form (>= 5.0.2)
   simplecov
+  simplecov-cobertura
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,3 +66,4 @@ services:
       - $HOME/bundle:/app/vendor/bundle
       - $HOME/.bundle_config:/app/.bundle
       - $HOME/node_modules:/app/node_modules
+      - $HOME/coverage:/app/coverage

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 
-# simplecov and codacy coverage
+# simplecov and cobertura formatter
 require 'simplecov'
 SimpleCov.start 'rails' do
   add_filter '/app/channels'
@@ -13,8 +13,10 @@ SimpleCov.start 'rails' do
   add_group 'Validators', 'app/validators'
 end
 
-require 'codacy-coverage' if ENV['CI']
-Codacy::Reporter.start if ENV['CI']
+if ENV['CI']
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+end
 
 require 'minitest/autorun'
 require 'minitest/focus'


### PR DESCRIPTION
#### Bu PR'in yaptığı işi/değişikliği ve bu işi/değişikliği neden yaptığını açıklayın

Daha önceden kullandığımız [codacy-coverage](https://github.com/codacy/ruby-codacy-coverage) gem'inin desteğini kaldırmışlar. Bunun yerine [codacy-coverage-reporter](https://github.com/codacy/codacy-coverage-reporter) isimli bir araç geliştirmişler. Coverage raporunu [simplecov-cobertura](https://github.com/dashingrocket/simplecov-cobertura) gem'iyle uygun formata getirip, codacy-coverage-reporter ile codacy'e yüklüyoruz.

#### Kontrol listesi

- [x] [Katkı sağlama dokümanını](../blob/master/.github/CONTRIBUTING.md) okudum
- [x] İş kaydının başlığı kurallara (sadece ilk harf büyük, emir kipinde problem cümlesi) uygun
- [x] Yapılan iş/değişikliği dokümante ettim
- [x] Yapılan iş/değişikliğin testlerini yazdım
- [x] Test coverage oranını kontrol ettim
- [x] Kod kalitesi (karma) ve test suite dahil olmak üzere tüm entegre kontroller başarıyla geçiyor
- [x] Kendimi bu PR'e assign ettim
- [x] Yapılan iş/değişiklik ile ilgili proje üyelerinden review talep ettim
- [x] Gerekli etiketlemeyi (ör. bug) yaptım
